### PR TITLE
fix a race condition, make things faster, profit

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -299,7 +299,7 @@ func executeFields(p ExecuteFieldsParams) *Result {
 		}
 		if resolve, ok := resolved.(deferredResolveFunction); ok {
 			numberOfDeferredFunctions += 1
-			go func() {
+			go func(responseName string) {
 				defer func() {
 					recoverChan <- recover()
 				}()
@@ -307,7 +307,7 @@ func executeFields(p ExecuteFieldsParams) *Result {
 				resultsMutex.Lock()
 				defer resultsMutex.Unlock()
 				finalResults[responseName] = resolve()
-			}()
+			}(responseName)
 		} else {
 			resultsMutex.Lock()
 			finalResults[responseName] = resolved

--- a/executor.go
+++ b/executor.go
@@ -304,9 +304,11 @@ func executeFields(p ExecuteFieldsParams) *Result {
 					recoverChan <- recover()
 				}()
 
+				res := resolve()
+
 				resultsMutex.Lock()
 				defer resultsMutex.Unlock()
-				finalResults[responseName] = resolve()
+				finalResults[responseName] = res
 			}(responseName)
 		} else {
 			resultsMutex.Lock()


### PR DESCRIPTION
A pull request for a pull request? I guess that's a thing!

This has two commits, which I think are in line with your proposed changes.

1. I fixed a sneaky bug with slow async field resolvers overwriting the results of later fields, which was rooted in the reference to `responseName` being changed between attaining the async resolver and actually resolving it.
2. I made it so resolvers all run as soon as possible rather than serialising on `resultsMutex`. I think this is in line with your goals of making things concurrent.

Feel free to take one, both, or neither of these.